### PR TITLE
Added endpoint for multiple submission delete

### DIFF
--- a/app.py
+++ b/app.py
@@ -492,14 +492,14 @@ def delete_submissions(user_id):
     for submission_id in ids:
         # Delete matching submissions
         submission_ref = db.reference(f'users/{user_id}/submissions/{submission_id}')
-        
-        # Check if submission exists
+
+        # Check if submission exists; skip missing IDs to allow partial success
         submission = submission_ref.get()
         if not submission:
-            return error('Submission not found', code='not_found', status=404)
-        
+            continue
+
         project_id = submission.get('projectid')
-        
+
         # Remove submission ID from project's fileids
         if project_id:
             project_ref = db.reference(f'users/{user_id}/projects/{project_id}')
@@ -512,25 +512,24 @@ def delete_submissions(user_id):
                         'fileids': fileids,
                         'updated_at': get_timestamp()
                     })
-        
+
         # Delete the submission
         submission_ref.delete()
-
         deleted_submissions += 1
 
-        if deleted_submissions == 0:
+    if deleted_submissions == 0:
         # Nothing matched the provided IDs – surface this clearly to the client
-            return error(
-                "No matching projects found for provided IDs",
-                code="not_found",
-                status=404,
-            )      
+        return error(
+            "No matching submissions found for provided IDs",
+            code="not_found",
+            status=404,
+        )
 
     return success(
         meta={
-            "message": f"Deleted {deleted_submissions} project(s) and related submissions successfully"
+            "message": f"Deleted {deleted_submissions} submission(s) successfully"
         }
-    )    
+    )
 
 # History endpoints
 

--- a/postman/SecureBYTE_Review_Endpoints.postman_collection.json
+++ b/postman/SecureBYTE_Review_Endpoints.postman_collection.json
@@ -432,6 +432,64 @@
             }
           },
           "response": []
+        },
+        {
+          "name": "Batch Delete Submissions",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Ensure at least one submission_id is set; run Setup → Create Submission first if needed.",
+                  "if (!pm.collectionVariables.get('submission_id')) {",
+                  "  throw new Error('submission_id is not set. Run Setup → Create Submission first to get a sample ID.');",
+                  "}"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "try {",
+                  "  var data = pm.response.json();",
+                  "  pm.test('Response indicates success', function () {",
+                  "    pm.expect(data.success).to.be.true;",
+                  "  });",
+                  "} catch (e) {",
+                  "  console.warn('Response not JSON or missing success flag');",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"ids\": [\n    \"{{submission_id}}\"\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/users/{{user_id}}/submissions_delete",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "users",
+                "{{user_id}}",
+                "submissions_delete"
+              ]
+            }
+          },
+          "response": []
         }
       ]
     }


### PR DESCRIPTION
- Added an api endpoint '/users/<user_id>/submissions_delete' to allow deletion of multiple submissions at once
- Helps prevent multiple calls to the server
- Followed structure of delete_projects to ensure uniformity